### PR TITLE
Bugfix when using os sep in test case name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
 - Delete the output dir before generating tests ([#7]).
 
+### Changed
+
+- Replace os fs separator ("/") in test case names with underscore ("_") ([#8])
+
 [#7]: https://github.com/stackabletech/beku.py/pull/7)
+[#8]: https://github.com/stackabletech/beku.py/pull/8)
 
 ## [0.0.8] - 2023-07-01
 

--- a/src/beku/kuttl.py
+++ b/src/beku/kuttl.py
@@ -106,13 +106,16 @@ class TestCase:
 
     @cached_property
     def tid(self) -> str:
-        """Return the test id. Used as destination folder name for the generated test case."""
-        return "_".join(
+        """Return the test id. Used as destination folder name for the generated test case.
+        The result is part of a full directory name of the test case. Therefore, the OS filesystem
+        directory separator is replaced with underscore.
+        """
+        return re.sub(f"[{os.sep}:]", "_", "_".join(
             chain(
                 [self.name],
                 [f"{k}-{v}" for k, v in self.values.items()],
             )
-        )
+        ))
 
     def expand(self, template_dir: str, target_dir: str) -> None:
         """Expand test case This will create the target folder, copy files and render render templates."""


### PR DESCRIPTION
Test case ids are made up of the test names and dimension values. If any of these contains the os sep name, the wrong directory hierarachy is generated.

Discovered in : https://github.com/stackabletech/spark-k8s-operator/pull/275