### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ But you can also use `pip`:
     # from PyPI
     pip install beku-stackabletech
     # from GitHub
-    pip install git+https://github.com/stackabletech/beku.py.git@master
+    pip install git+https://github.com/stackabletech/beku.py.git@main
 
 ## Usage
 


### PR DESCRIPTION
The branch ref in the readme still was master instead of main, which caused the pip install command to fail.