### PR TITLE
feat: determine namespace from testcase name and provide it as variable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,4 +63,4 @@ repos:
         language: python
         'types': [python]
         pass_filenames: false
-        stages: [commit]
+        stages: [pre-commit]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ All notable changes to this project will be documented in this file.
 - Raise build versions ([#18])
 - Use setuptools to build the project ([#18])
 - Drop support for 3.10 and add support for 3.12 ([#18])
+- Added NAMESPACE to template globals and --namespace cli argument for preferred names ([#30])
 
 [#18]: https://github.com/stackabletech/beku.py/pull/18
+[#30]: https://github.com/stackabletech/beku.py/pull/30
 
 ## [0.0.9] - 2023-08-23
 

--- a/src/beku/kuttl.py
+++ b/src/beku/kuttl.py
@@ -125,7 +125,7 @@ class TestCase:
             ),
         )
 
-    def expand(self, template_dir: str, target_dir: str) -> None:
+    def expand(self, template_dir: str, target_dir: str, namespace: str) -> None:
         """Expand test case This will create the target folder, copy files and render render templates."""
         logging.info("Expanding test case id [%s]", self.tid)
         td_root = path.join(template_dir, self.name)
@@ -133,7 +133,7 @@ class TestCase:
         _mkdir_ignore_exists(tc_root)
         test_env = Environment(loader=FileSystemLoader(path.join(template_dir, self.name)), trim_blocks=True)
         test_env.globals["lookup"] = ansible_lookup
-        test_env.globals["NAMESPACE"] = determine_namespace(self.tid)
+        test_env.globals["NAMESPACE"] = determine_namespace(self.tid, namespace)
         sub_level: int = 0
         for root, dirs, files in walk(td_root):
             sub_level += 1
@@ -315,7 +315,12 @@ class EffectiveTestSuite:
 
 
 def expand(
-    suite: str, effective_test_suites: List[EffectiveTestSuite], template_dir: str, output_dir: str, kuttl_tests: str
+    suite: str,
+    effective_test_suites: List[EffectiveTestSuite],
+    template_dir: str,
+    output_dir: str,
+    kuttl_tests: str,
+    namespace: str,
 ) -> int:
     """Expand test suite."""
     try:
@@ -324,14 +329,14 @@ def expand(
         _mkdir_ignore_exists(output_dir)
         _expand_kuttl_tests(ets.test_cases, output_dir, kuttl_tests)
         for test_case in ets.test_cases:
-            test_case.expand(template_dir, output_dir)
+            test_case.expand(template_dir, output_dir, namespace)
     except StopIteration as exc:
         raise ValueError(f"Cannot expand test suite [{suite}] because cannot find it in [{kuttl_tests}]") from exc
     return 0
 
 
-def determine_namespace(testcase_name: str) -> str:
-    """Generate a namespace name for the given test case.
+def determine_namespace(testcase_name: str, prefered_namespace: str) -> str:
+    """Generate a namespace name for the given test case unless a prefered namespace name is given.
 
     The format of the namespace name is "kuttl-<hash>" where hash is the first 10 chars of the test
     case's sha256 value.
@@ -343,8 +348,11 @@ def determine_namespace(testcase_name: str) -> str:
     different syntactic restrictions.
     Therefore, to be on the safe side, the namespace name is kept as simple as possible.
     """
-    hash = sha256(testcase_name.encode("utf-8")).hexdigest()
-    return f"kuttl-{hash[:10]}"
+    if prefered_namespace:
+        return prefered_namespace
+    else:
+        hash = sha256(testcase_name.encode("utf-8")).hexdigest()
+        return f"kuttl-{hash[:10]}"
 
 
 def _expand_kuttl_tests(test_cases, output_dir: str, kuttl_tests: str) -> None:

--- a/src/beku/kuttl.py
+++ b/src/beku/kuttl.py
@@ -331,6 +331,18 @@ def expand(
 
 
 def determine_namespace(testcase_name: str) -> str:
+    """Generate a namespace name for the given test case.
+
+    The format of the namespace name is "kuttl-<hash>" where hash is the first 10 chars of the test
+    case's sha256 value.
+
+    There is an analogous function in "kubectl-kuttl" that generates the exact same namespace name.
+    These two have to be kept in sync!
+
+    The tests use the namespace name also for other kubernetes objects like "metadata.name" which have
+    different syntactic restrictions.
+    Therefore, to be on the safe side, the namespace name is kept as simple as possible.
+    """
     hash = sha256(testcase_name.encode("utf-8")).hexdigest()
     return f"kuttl-{hash[:10]}"
 

--- a/src/beku/kuttl.py
+++ b/src/beku/kuttl.py
@@ -332,7 +332,7 @@ def expand(
 
 def determine_namespace(testcase_name: str) -> str:
     hash = sha256(testcase_name.encode("utf-8")).hexdigest()
-    return f"kuttl-{testcase_name[:32]}-{hash[:10]}"
+    return f"kuttl-{hash[:10]}"
 
 
 def _expand_kuttl_tests(test_cases, output_dir: str, kuttl_tests: str) -> None:

--- a/src/beku/main.py
+++ b/src/beku/main.py
@@ -69,6 +69,14 @@ def parse_cli_args() -> Namespace:
         default="default",
     )
 
+    parser.add_argument(
+        "-n",
+        "--namespace",
+        help="Name of the namespace to use for tests. Default: kuttl-<test name sha256>",
+        type=str,
+        required=False,
+    )
+
     return parser.parse_args()
 
 
@@ -86,4 +94,11 @@ def main() -> int:
     rmtree(path=cli_args.output_dir, ignore_errors=True)
     # Compatibility warning: add 'tests' to output_dir
     output_dir = path.join(cli_args.output_dir, "tests")
-    return expand(cli_args.suite, effective_test_suites, cli_args.template_dir, output_dir, cli_args.kuttl_test)
+    return expand(
+        cli_args.suite,
+        effective_test_suites,
+        cli_args.template_dir,
+        output_dir,
+        cli_args.kuttl_test,
+        cli_args.namespace,
+    )

--- a/src/beku/version.py
+++ b/src/beku/version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "0.0.9"
+__version__ = "0.0.10"


### PR DESCRIPTION
Determine the namespace by generating it from the testcase name, analog to our [kuttl fork](https://github.com/stackabletech/kuttl/blob/d294f6232a8d34074662d89a1a628a284006689e/pkg/test/harness.go#L64-L74).