### PR TITLE
chore: update examples to use bitnamilegacy

### DIFF
--- a/examples/suites/tests/templates/kuttl/cluster-operation/helm-bitnami-postgresql-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/cluster-operation/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/cluster-operation/helm-bitnami-redis-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/cluster-operation/helm-bitnami-redis-values.yaml.j2
@@ -1,8 +1,33 @@
 ---
+global:
+  security:
+    allowInsecureImages: true
+
+image:
+  repository: bitnamilegacy/redis
+
+sentinel:
+  image:
+    repository: bitnamilegacy/redis-sentinel
+
+metrics:
+  image:
+    repository: bitnamilegacy/redis-exporter
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   containerSecurityContext:
     runAsUser: auto
+
+kubectl:
+  image:
+    repository: bitnamilegacy/kubectl
+
+sysctl:
+  image:
+    repository: bitnamilegacy/os-shell
 
 master:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/ldap/03-install-openldap.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/ldap/03-install-openldap.yaml.j2
@@ -40,7 +40,7 @@ commands:
             serviceAccountName: "ldap-sa"
             containers:
               - name: openldap
-                image: docker.io/bitnami/openldap:2.5
+                image: docker.io/bitnamilegacy/openldap:2.5
                 env:
                   - name: LDAP_ADMIN_USERNAME
                     value: admin

--- a/examples/suites/tests/templates/kuttl/ldap/helm-bitnami-postgresql-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/ldap/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/ldap/helm-bitnami-redis-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/ldap/helm-bitnami-redis-values.yaml.j2
@@ -1,8 +1,33 @@
 ---
+global:
+  security:
+    allowInsecureImages: true
+
+image:
+  repository: bitnamilegacy/redis
+
+sentinel:
+  image:
+    repository: bitnamilegacy/redis-sentinel
+
+metrics:
+  image:
+    repository: bitnamilegacy/redis-exporter
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   containerSecurityContext:
     runAsUser: auto
+
+kubectl:
+  image:
+    repository: bitnamilegacy/kubectl
+
+sysctl:
+  image:
+    repository: bitnamilegacy/os-shell
 
 master:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/logging/helm-bitnami-postgresql-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/logging/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/logging/helm-bitnami-redis-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/logging/helm-bitnami-redis-values.yaml.j2
@@ -1,8 +1,33 @@
 ---
+global:
+  security:
+    allowInsecureImages: true
+
+image:
+  repository: bitnamilegacy/redis
+
+sentinel:
+  image:
+    repository: bitnamilegacy/redis-sentinel
+
+metrics:
+  image:
+    repository: bitnamilegacy/redis-exporter
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   containerSecurityContext:
     runAsUser: auto
+
+kubectl:
+  image:
+    repository: bitnamilegacy/kubectl
+
+sysctl:
+  image:
+    repository: bitnamilegacy/os-shell
 
 master:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/mount-dags-configmap/helm-bitnami-postgresql-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/mount-dags-configmap/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/mount-dags-configmap/helm-bitnami-redis-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/mount-dags-configmap/helm-bitnami-redis-values.yaml.j2
@@ -1,8 +1,33 @@
 ---
+global:
+  security:
+    allowInsecureImages: true
+
+image:
+  repository: bitnamilegacy/redis
+
+sentinel:
+  image:
+    repository: bitnamilegacy/redis-sentinel
+
+metrics:
+  image:
+    repository: bitnamilegacy/redis-exporter
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   containerSecurityContext:
     runAsUser: auto
+
+kubectl:
+  image:
+    repository: bitnamilegacy/kubectl
+
+sysctl:
+  image:
+    repository: bitnamilegacy/os-shell
 
 master:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/mount-dags-gitsync/helm-bitnami-postgresql-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/mount-dags-gitsync/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/mount-dags-gitsync/helm-bitnami-redis-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/mount-dags-gitsync/helm-bitnami-redis-values.yaml.j2
@@ -1,8 +1,33 @@
 ---
+global:
+  security:
+    allowInsecureImages: true
+
+image:
+  repository: bitnamilegacy/redis
+
+sentinel:
+  image:
+    repository: bitnamilegacy/redis-sentinel
+
+metrics:
+  image:
+    repository: bitnamilegacy/redis-exporter
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   containerSecurityContext:
     runAsUser: auto
+
+kubectl:
+  image:
+    repository: bitnamilegacy/kubectl
+
+sysctl:
+  image:
+    repository: bitnamilegacy/os-shell
 
 master:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/orphaned-resources/helm-bitnami-postgresql-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/orphaned-resources/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/orphaned-resources/helm-bitnami-redis-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/orphaned-resources/helm-bitnami-redis-values.yaml.j2
@@ -1,8 +1,33 @@
 ---
+global:
+  security:
+    allowInsecureImages: true
+
+image:
+  repository: bitnamilegacy/redis
+
+sentinel:
+  image:
+    repository: bitnamilegacy/redis-sentinel
+
+metrics:
+  image:
+    repository: bitnamilegacy/redis-exporter
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   containerSecurityContext:
     runAsUser: auto
+
+kubectl:
+  image:
+    repository: bitnamilegacy/kubectl
+
+sysctl:
+  image:
+    repository: bitnamilegacy/os-shell
 
 master:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/resources/helm-bitnami-postgresql-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/resources/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/resources/helm-bitnami-redis-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/resources/helm-bitnami-redis-values.yaml.j2
@@ -1,8 +1,33 @@
 ---
+global:
+  security:
+    allowInsecureImages: true
+
+image:
+  repository: bitnamilegacy/redis
+
+sentinel:
+  image:
+    repository: bitnamilegacy/redis-sentinel
+
+metrics:
+  image:
+    repository: bitnamilegacy/redis-exporter
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   containerSecurityContext:
     runAsUser: auto
+
+kubectl:
+  image:
+    repository: bitnamilegacy/kubectl
+
+sysctl:
+  image:
+    repository: bitnamilegacy/os-shell
 
 master:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/smoke/helm-bitnami-postgresql-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/smoke/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/examples/suites/tests/templates/kuttl/smoke/helm-bitnami-redis-values.yaml.j2
+++ b/examples/suites/tests/templates/kuttl/smoke/helm-bitnami-redis-values.yaml.j2
@@ -1,8 +1,33 @@
 ---
+global:
+  security:
+    allowInsecureImages: true
+
+image:
+  repository: bitnamilegacy/redis
+
+sentinel:
+  image:
+    repository: bitnamilegacy/redis-sentinel
+
+metrics:
+  image:
+    repository: bitnamilegacy/redis-exporter
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   containerSecurityContext:
     runAsUser: auto
+
+kubectl:
+  image:
+    repository: bitnamilegacy/kubectl
+
+sysctl:
+  image:
+    repository: bitnamilegacy/os-shell
 
 master:
   podSecurityContext:


### PR DESCRIPTION
This was missed during the bitnami migration. Part of https://github.com/stackabletech/issues/issues/749 Quickfix.
This PR updates the examples to use the bitnamilegacy repository for bitnami images.